### PR TITLE
CIT-101 feature(SM,KMS): Create initial version of Secret Manager

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @loomispay/sre

--- a/README.md
+++ b/README.md
@@ -30,29 +30,8 @@ The actual value should be updated via awscli or AWS console, and then, to refre
 
 ## Examples
 
-### Create
+Check [examples directory](./examples/complete)
 
-```
-module "secrets" {
-  source = "git::https://github.com/loomispay/terraform-aws-secretsmanager.git?ref=main"
-
-  namespace              = "marketing"
-  environment            = "prod"
-  name                   = "analytics-service"
-  secrets = {
-    secret_name_1 = "change_me"
-    secret_name_2 = "change_me"
-  }
-}
-```
-
-### Read
-
-```
-resource "null_resource" "secretsmanager" {
-  secret_value = module.secrets.secrets_values.secret_name_1
-}
-```
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,117 @@
+# Overview
+
+AWS Secrets Manager helps you to securely encrypt, store, and retrieve credentials for your databases and other services. Instead of hardcoding credentials in your apps, you can make calls to Secrets Manager to retrieve your credentials whenever needed. 
+Secrets Manager helps you protect access to your IT resources and data by enabling you to rotate and manage access to your secrets.
+
+## Assumptions
+
+Security and backup/recovery are critical aspects of any software system. It is important to ensure that they are addressed properly to minimize risks and vulnerabilities. 
+In this section, we will outline the security and backup/recovery requirements that are necessary to ensure the protection of our system, users, and data.
+All the assumptions required have been agreed and collected below
+
+| Assumption                         | Reason                                                                                    |
+|------------------------------------|-------------------------------------------------------------------------------------------|
+| Secrets multi-region availability  | Increase security through data encryption                                                 |
+| Secrets multi-region availability  | introduce disaster recovery achieve mechanism by storing secrets in multiple data centers |
+ | 30-day recovery window             | Guarantee integrity of data by eliminating accidental removing critical data              |
+ | Creation multiple secret at once   | Just for convenience with working with this module                                        |
+
+## Alternatives modules
+
+On the Open Source market there are two alternatives modules. Both of them unfortunately haven't met our security and safety requirements, described above
+- [lgallard](https://github.com/lgallard/terraform-aws-secrets-manager) - does not use KMS at all
+- [SweetOps](https://github.com/SweetOps/terraform-aws-secretsmanager) - does not have multi-region KMS and multiple secrets at once
+
+## Way of working
+
+To guarantee that all the infrastructure is stored as a code it is needed to reflect also secrets creation here.
+Placeholder (i.e. "change_me") for value should be provided, to avoid leaking critical data such like user, password, database url, tokens, ssh keys in the infrastructure code.
+The actual value should be updated via awscli or AWS console, and then, to refresh value in local terraform state you should run terraform plan and apply once again to read the proper value from Secret Manager.
+
+## Examples
+
+### Create
+
+```
+module "secrets" {
+  source = "git::https://github.com/loomispay/terraform-aws-secretsmanager.git?ref=main"
+
+  namespace              = "marketing"
+  environment            = "prod"
+  name                   = "analytics-service"
+  secrets = {
+    secret_name_1 = "change_me"
+    secret_name_2 = "change_me"
+  }
+}
+```
+
+### Read
+
+```
+resource "null_resource" "secretsmanager" {
+  secret_value = module.secrets.secrets_values.secret_name_1
+}
+```
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.57 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.57 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_kms_primary"></a> [kms\_primary](#module\_kms\_primary) | git::https://github.com/terraform-aws-modules/terraform-aws-kms.git | v1.5.0 |
+| <a name="module_kms_replica"></a> [kms\_replica](#module\_kms\_replica) | git::https://github.com/terraform-aws-modules/terraform-aws-kms.git | v1.5.0 |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_secretsmanager_secret.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_version.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | ARN or Id of the AWS KMS key to be used to encrypt the secret values in the versions stored in this secret. Provided KMS must be replicated to replica region | `string` | `""` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
+| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_replica_region"></a> [replica\_region](#input\_replica\_region) | Region for replicating the secret | `string` | `"eu-central-1"` | no |
+| <a name="input_secrets"></a> [secrets](#input\_secrets) | A map of secrets name and value to be created | `map(string)` | n/a | yes |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_secrets_values"></a> [secrets\_values](#output\_secrets\_values) | n/a |
+<!-- END_TF_DOCS -->

--- a/context.tf
+++ b/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -1,0 +1,52 @@
+# Complete AWS Secrets Manager Example
+
+Configuration in this directory:
+
+- KMS key with multi-region replication
+- Secret Manager with secrets define via appropriate variable
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.57 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.1 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_secrets"></a> [secrets](#module\_secrets) | git::https://github.com/loomispay/terraform-aws-secretsmanager.git | feature/CIT-101-initial-version |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [null_resource.secretsmanager](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,0 +1,23 @@
+module "secrets" {
+  source = "git::https://github.com/loomispay/terraform-aws-secretsmanager.git?ref=feature/CIT-101-initial-version"
+
+  enabled = true
+  namespace              = "important-domain-name"
+  environment            = "stag"
+  name                   = "backend-service"
+  replica_region         = "us-east-1"
+  secrets = {
+    secret_name_1 = "change_me"
+    secret_name_2 = "change_me"
+  }
+}
+
+#####################################################
+######## READ SECRETS FROM SECRET MANAGER ###########
+#####################################################
+
+resource "null_resource" "secretsmanager" {
+  provisioner "local-exec" {
+    command = "echo ${module.secrets.secrets_values.secret_name_1}"
+  }
+}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,5 +1,5 @@
 module "secrets" {
-  source = "git::https://github.com/loomispay/terraform-aws-secretsmanager.git?ref=feature/CIT-101-initial-version"
+  source = "git::https://github.com/loomispay/terraform-aws-secretsmanager.git"
 
   enabled = true
   namespace              = "important-domain-name"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.57"
+    }
+  }
+}
+
+provider "aws" {
+  alias = "replica"
+  region = var.replica_region
+}

--- a/kms.tf
+++ b/kms.tf
@@ -10,7 +10,7 @@ module "kms_primary" {
 
   aliases                  = [format("alias/%v", module.this.id)]
   deletion_window_in_days  = local.deletion_window_in_days
-  enable_key_rotation      = false
+  enable_key_rotation      = true
   multi_region             = true
   key_usage                = "ENCRYPT_DECRYPT"
   customer_master_key_spec = "SYMMETRIC_DEFAULT"

--- a/kms.tf
+++ b/kms.tf
@@ -1,6 +1,6 @@
 locals {
   deletion_window_in_days = 30
-  create                  = module.this.enabled && var.kms_key_id == "" ? true : false
+  create                  = module.this.enabled && var.kms_key_id ? true : false
 }
 
 module "kms_primary" {
@@ -14,7 +14,7 @@ module "kms_primary" {
   multi_region             = true
   key_usage                = "ENCRYPT_DECRYPT"
   customer_master_key_spec = "SYMMETRIC_DEFAULT"
-  description              = "External key example"
+  description              = "KMS key to be used to encrypt the values for Secret Manager"
 
   tags                     = module.this.tags
 }

--- a/kms.tf
+++ b/kms.tf
@@ -1,0 +1,38 @@
+locals {
+  deletion_window_in_days = 30
+  create                  = module.this.enabled && var.kms_key_id == "" ? true : false
+}
+
+module "kms_primary" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-kms.git?ref=v1.5.0"
+
+  count                    = local.create ? 1 : 0
+
+  aliases                  = [format("alias/%v", module.this.id)]
+  deletion_window_in_days  = local.deletion_window_in_days
+  enable_key_rotation      = false
+  multi_region             = true
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  description              = "External key example"
+
+  tags                     = module.this.tags
+}
+
+module "kms_replica" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-kms.git?ref=v1.5.0"
+
+  count                   = local.create ? 1 : 0
+
+  primary_key_arn         = module.kms_primary[0].key_arn
+  deletion_window_in_days = local.deletion_window_in_days
+  create_replica          = true
+  enable_default_policy   = true
+  description             = "Multi-Region replica key"
+
+  tags                    = module.this.tags
+
+  providers = {
+    aws = aws.replica
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,29 @@
+resource "aws_secretsmanager_secret" "default" {
+  for_each = var.enabled ? var.secrets : {}
+
+  name                    = each.key
+  recovery_window_in_days = 30
+  kms_key_id              = coalesce(var.kms_key_id, module.kms_primary[0].key_id)
+  replica {
+    region     = var.replica_region
+    kms_key_id = coalesce(var.kms_key_id, module.kms_replica[0].key_id)
+  }
+
+  tags = module.this.tags
+}
+
+resource "aws_secretsmanager_secret_version" "default" {
+  for_each = var.enabled ? var.secrets : {}
+
+  secret_id     = aws_secretsmanager_secret.default[each.key].id
+  secret_string = each.value
+}
+
+# ============== READ SECRETS FROM SECRET MANAGER ==============
+
+data "aws_secretsmanager_secret_version" "default" {
+  for_each  = var.secrets
+  secret_id = each.key
+
+  depends_on = [aws_secretsmanager_secret_version.default]
+}

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,9 @@ resource "aws_secretsmanager_secret_version" "default" {
   secret_string = each.value
 }
 
-# ============== READ SECRETS FROM SECRET MANAGER ==============
+#####################################################
+######## READ SECRETS FROM SECRET MANAGER ###########
+#####################################################
 
 data "aws_secretsmanager_secret_version" "default" {
   for_each  = var.secrets

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,4 @@
+output "secrets_values" {
+  value = { for v in data.aws_secretsmanager_secret_version.default : v.secret_id => v.secret_string }
+  sensitive = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,16 @@
+variable "secrets" {
+  type = map(string)
+  description = "A map of secrets name and value to be created"
+}
+
+variable "replica_region" {
+  type        = string
+  default     = "eu-central-1"
+  description = "Region for replicating the secret"
+}
+
+variable "kms_key_id" {
+  type        = string
+  default     = ""
+  description = "ARN or Id of the AWS KMS key to be used to encrypt the secret values in the versions stored in this secret. Provided KMS must be replicated to replica region"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -5,12 +5,12 @@ variable "secrets" {
 
 variable "replica_region" {
   type        = string
-  default     = "eu-central-1"
+  default     = "eu-west-1"
   description = "Region for replicating the secret"
 }
 
 variable "kms_key_id" {
   type        = string
-  default     = ""
+  default     = null
   description = "ARN or Id of the AWS KMS key to be used to encrypt the secret values in the versions stored in this secret. Provided KMS must be replicated to replica region"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.57"
+    }
+  }
+}
+
+provider "aws" {
+  alias = "replica"
+  region = var.replica_region
+}


### PR DESCRIPTION
AWS Secrets Manager helps you to securely encrypt, store, and retrieve credentials for your databases and other services. Unfortunately there are no open source modules met our 4 main requirements:

- [x] Custom multi-region Key Management Service (KMS)
- [x] Secrets multi-region availability
- [x] 30-day recovery window
- [x] Creation multiple secret at once

Having that in mind this module was created. Good Luck and have fun 😄