### PR TITLE
CIT-101 fix(SM): Fix a way how KMS is selected once it is provided

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,10 +3,10 @@ resource "aws_secretsmanager_secret" "default" {
 
   name                    = each.key
   recovery_window_in_days = 30
-  kms_key_id              = coalesce(var.kms_key_id, module.kms_primary[0].key_id)
+  kms_key_id              = try(module.kms_primary[0].key_id, var.kms_key_id)
   replica {
     region     = var.replica_region
-    kms_key_id = coalesce(var.kms_key_id, module.kms_replica[0].key_id)
+    kms_key_id = try(module.kms_replica[0].key_id, var.kms_key_id)
   }
 
   tags = module.this.tags


### PR DESCRIPTION
It turns out that coalesce does not skip validation of empty list. 
Terraform 'try' used instead