### PR TITLE
CIT-101 feature(SM): Extend outputs by ARN of created secrets

### DIFF
--- a/kms.tf
+++ b/kms.tf
@@ -1,6 +1,6 @@
 locals {
   deletion_window_in_days = 30
-  create                  = alltrue([module.this.enabled, var.kms_key_id == null])
+  create                  = alltrue([module.this.enabled, var.kms_key_alias == null])
 }
 
 module "kms_primary" {

--- a/main.tf
+++ b/main.tf
@@ -3,10 +3,10 @@ resource "aws_secretsmanager_secret" "default" {
 
   name                    = each.key
   recovery_window_in_days = 30
-  kms_key_id              = try(module.kms_primary[0].key_id, var.kms_key_id)
+  kms_key_id              = try(module.kms_primary[0].key_id, var.kms_key_alias)
   replica {
     region     = var.replica_region
-    kms_key_id = try(module.kms_replica[0].key_id, var.kms_key_id)
+    kms_key_id = try(module.kms_replica[0].key_id, var.kms_key_alias)
   }
 
   tags = module.this.tags

--- a/output.tf
+++ b/output.tf
@@ -2,3 +2,7 @@ output "secrets_values" {
   value = { for v in data.aws_secretsmanager_secret_version.default : v.secret_id => v.secret_string }
   sensitive = true
 }
+
+output "secrets_arns" {
+  value = {for v in aws_secretsmanager_secret.default : v.name => v.arn}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,8 +9,8 @@ variable "replica_region" {
   description = "Region for replicating the secret"
 }
 
-variable "kms_key_id" {
+variable "kms_key_alias" {
   type        = string
   default     = null
-  description = "ARN or Id of the AWS KMS key to be used to encrypt the secret values in the versions stored in this secret. Provided KMS must be replicated to replica region"
+  description = "Alias of the AWS KMS key to be used to encrypt the secret values in the versions stored in this secret. Provided KMS must be replicated to replica region"
 }


### PR DESCRIPTION
- Extend outputs by ARN of created secrets
- Change input KMS variable name to alias. ARN could not be provided, because we are using it for replica, so the ARN is different